### PR TITLE
Kill redundancy

### DIFF
--- a/MiniAODHelper/interface/MiniAODHelper.h
+++ b/MiniAODHelper/interface/MiniAODHelper.h
@@ -127,11 +127,8 @@ class MiniAODHelper{
   virtual bool isGoodElectron(const pat::Electron&, const float, const electronID::electronID);
   virtual bool isGoodTau(const pat::Tau&, const float, const tau::ID);
   virtual bool isGoodJet(const pat::Jet&, const float, const float, const jetID::jetID, const char);
-  //  virtual float GetMuonRelIso(const pat::Muon&) const;
-  float GetMuonRelIso(const pat::Muon&) const;
-  float GetMuonRelIso(const pat::Muon&, const coneSize::coneSize, const corrType::corrType) const;
-  float GetElectronRelIso(const pat::Electron&) const;
-  float GetElectronRelIso(const pat::Electron&, const coneSize::coneSize, const corrType::corrType) const;
+  float GetMuonRelIso(const pat::Muon&, const coneSize::coneSize=coneSize::R03, const corrType::corrType=corrType::deltaBeta) const;
+  float GetElectronRelIso(const pat::Electron&, const coneSize::coneSize=coneSize::R03, const corrType::corrType=corrType::deltaBeta) const;
   bool PassesCSV(const pat::Jet&, const char);
   bool PassElectronPhys14Id(const pat::Electron&, const electronID::electronID) const;
 

--- a/MiniAODHelper/src/MiniAODHelper.cc
+++ b/MiniAODHelper/src/MiniAODHelper.cc
@@ -527,22 +527,6 @@ MiniAODHelper::isGoodJet(const pat::Jet& iJet, const float iMinPt, const float i
   return true;
 }
 
-
-float MiniAODHelper::GetMuonRelIso(const pat::Muon& iMuon) const
-{
-  float result = 9999; 
-
-  double pfIsoCharged = iMuon.pfIsolationR03().sumChargedHadronPt;
-  double pfIsoNeutral = iMuon.pfIsolationR03().sumNeutralHadronEt + iMuon.pfIsolationR03().sumPhotonEt;
-
-  double pfIsoPUSubtracted = std::max( 0.0, pfIsoNeutral - 0.5*iMuon.pfIsolationR03().sumPUPt );
-
-  result = (pfIsoCharged + pfIsoPUSubtracted)/iMuon.pt();
-  
-  return result;
-}
-
-//overloaded
 float MiniAODHelper::GetMuonRelIso(const pat::Muon& iMuon,const coneSize::coneSize iconeSize, const corrType::corrType icorrType) const
 {
   //rho corrections based on phys14
@@ -609,21 +593,6 @@ float MiniAODHelper::GetMuonRelIso(const pat::Muon& iMuon,const coneSize::coneSi
   return result;
 }
 
-float MiniAODHelper::GetElectronRelIso(const pat::Electron& iElectron) const
-{
-  float result = 9999; 
-
-  double pfIsoCharged = iElectron.pfIsolationVariables().sumChargedHadronPt;
-  double pfIsoNeutral = iElectron.pfIsolationVariables().sumNeutralHadronEt + iElectron.pfIsolationVariables().sumPhotonEt;
-
-  double pfIsoPUSubtracted = std::max( 0.0, pfIsoNeutral - 0.5*iElectron.pfIsolationVariables().sumPUPt );
-
-  result = (pfIsoCharged + pfIsoPUSubtracted)/iElectron.pt();
-  
-  return result;
-}
-
-//overloaded
 float MiniAODHelper::GetElectronRelIso(const pat::Electron& iElectron,const coneSize::coneSize iconeSize, const corrType::corrType icorrType) const
 {
   //rho corrections based on phys14

--- a/MiniAODHelper/src/MiniAODHelper.cc
+++ b/MiniAODHelper/src/MiniAODHelper.cc
@@ -571,8 +571,13 @@ float MiniAODHelper::GetMuonRelIso(const pat::Muon& iMuon,const coneSize::coneSi
       pfIsoNeutral = iMuon.pfIsolationR04().sumNeutralHadronEt + iMuon.pfIsolationR04().sumPhotonEt;
       
       switch(icorrType){
-      case corrType::rhoEA: correction = useRho*EffArea; break;
-      case corrType::deltaBeta: correction =  0.5*iMuon.pfIsolationR04().sumPUPt; break;}
+      case corrType::rhoEA:
+         correction = useRho*EffArea;
+         break;
+      case corrType::deltaBeta:
+         correction =  0.5*iMuon.pfIsolationR04().sumPUPt;
+         break;
+      }
       
       pfIsoPUSubtracted = std::max( 0.0, pfIsoNeutral - correction );
       result = (pfIsoCharged + pfIsoPUSubtracted)/iMuon.pt();
@@ -588,8 +593,13 @@ float MiniAODHelper::GetMuonRelIso(const pat::Muon& iMuon,const coneSize::coneSi
       pfIsoNeutral = iMuon.pfIsolationR03().sumNeutralHadronEt + iMuon.pfIsolationR03().sumPhotonEt;
       
       switch(icorrType){
-      case corrType::rhoEA:  correction = useRho*EffArea; break;
-      case corrType::deltaBeta: correction = 0.5*iMuon.pfIsolationR03().sumPUPt; break;}
+      case corrType::rhoEA:
+         correction = useRho*EffArea;
+         break;
+      case corrType::deltaBeta:
+         correction = 0.5*iMuon.pfIsolationR03().sumPUPt;
+         break;
+      }
       
       pfIsoPUSubtracted = std::max( 0.0, pfIsoNeutral - correction );
       result = (pfIsoCharged + pfIsoPUSubtracted)/iMuon.pt();
@@ -643,8 +653,13 @@ float MiniAODHelper::GetElectronRelIso(const pat::Electron& iElectron,const cone
       pfIsoNeutral = iElectron.pfIsolationVariables().sumNeutralHadronEt + iElectron.pfIsolationVariables().sumPhotonEt;
       
       switch(icorrType){
-      case corrType::rhoEA:  correction = useRho*EffArea; break;
-      case corrType::deltaBeta: correction = 0.5*iElectron.pfIsolationVariables().sumPUPt; break;}
+      case corrType::rhoEA:
+         correction = useRho*EffArea;
+         break;
+      case corrType::deltaBeta:
+         correction = 0.5*iElectron.pfIsolationVariables().sumPUPt;
+         break;
+      }
       
       pfIsoPUSubtracted = std::max( 0.0, pfIsoNeutral - correction );
       result = (pfIsoCharged + pfIsoPUSubtracted)/iElectron.pt();


### PR DESCRIPTION
The current `Get*RelIso` functions have quite an overlap.  I would suggest we remove the short signature one by defining the corresponding default arguments for the complex function.  This should simplify future updates and make sure that things are in sync, by having only one `RelIso` function for e and µ each.