### PR TITLE
Changes in lepton ID (added eta cut as optional parameter)

### DIFF
--- a/MiniAODHelper/interface/MiniAODHelper.h
+++ b/MiniAODHelper/interface/MiniAODHelper.h
@@ -116,8 +116,8 @@ class MiniAODHelper{
 
   void SetFactorizedJetCorrector();
 
-  virtual std::vector<pat::Muon> GetSelectedMuons(const std::vector<pat::Muon>&, const float, const muonID::muonID, const coneSize::coneSize = coneSize::R04, const corrType::corrType = corrType::deltaBeta);
-  virtual std::vector<pat::Electron> GetSelectedElectrons(const std::vector<pat::Electron>&, const float, const electronID::electronID);
+  virtual std::vector<pat::Muon> GetSelectedMuons(const std::vector<pat::Muon>&, const float, const muonID::muonID, const coneSize::coneSize = coneSize::R04, const corrType::corrType = corrType::deltaBeta, const float = 2.4);
+  virtual std::vector<pat::Electron> GetSelectedElectrons(const std::vector<pat::Electron>&, const float, const electronID::electronID, const float = 2.4);
   std::vector<pat::Tau> GetSelectedTaus(const std::vector<pat::Tau>&, const float, const tau::ID);
   std::vector<pat::Jet> GetSelectedJets(const std::vector<pat::Jet>&, const float, const float, const jetID::jetID, const char);
   std::vector<pat::Jet> GetUncorrectedJets(const std::vector<pat::Jet>&);
@@ -125,8 +125,8 @@ class MiniAODHelper{
   std::vector<pat::Jet> GetCorrectedJets(const std::vector<pat::Jet>&, const edm::Event&, const edm::EventSetup&, const sysType::sysType iSysType=sysType::NA);
   std::vector<pat::Jet> GetCorrectedJets(const std::vector<pat::Jet>&, const sysType::sysType iSysType=sysType::NA);
 
-  bool isGoodMuon(const pat::Muon&, const float, const muonID::muonID, const coneSize::coneSize, const corrType::corrType);
-  bool isGoodElectron(const pat::Electron&, const float, const electronID::electronID);
+  bool isGoodMuon(const pat::Muon&, const float, const float, const muonID::muonID, const coneSize::coneSize, const corrType::corrType);
+  bool isGoodElectron(const pat::Electron&, const float, const float, const electronID::electronID);
   bool isGoodTau(const pat::Tau&, const float, const tau::ID);
   bool isGoodJet(const pat::Jet&, const float, const float, const jetID::jetID, const char);
   //  virtual float GetMuonRelIso(const pat::Muon&) const;

--- a/MiniAODHelper/interface/MiniAODHelper.h
+++ b/MiniAODHelper/interface/MiniAODHelper.h
@@ -116,7 +116,7 @@ class MiniAODHelper{
 
   void SetFactorizedJetCorrector();
 
-  virtual std::vector<pat::Muon> GetSelectedMuons(const std::vector<pat::Muon>&, const float, const muonID::muonID, const coneSize::coneSize = coneSize::R04, const corrType::corrType = corrType::deltaBeta, const float = 2.4);
+  virtual std::vector<pat::Muon> GetSelectedMuons(const std::vector<pat::Muon>&, const float, const muonID::muonID, const float = 2.4, const coneSize::coneSize = coneSize::R04, const corrType::corrType = corrType::deltaBeta);
   virtual std::vector<pat::Electron> GetSelectedElectrons(const std::vector<pat::Electron>&, const float, const electronID::electronID, const float = 2.4);
   std::vector<pat::Tau> GetSelectedTaus(const std::vector<pat::Tau>&, const float, const tau::ID);
   std::vector<pat::Jet> GetSelectedJets(const std::vector<pat::Jet>&, const float, const float, const jetID::jetID, const char);

--- a/MiniAODHelper/src/MiniAODHelper.cc
+++ b/MiniAODHelper/src/MiniAODHelper.cc
@@ -922,6 +922,9 @@ int MiniAODHelper::ttHFCategorization(const std::vector<reco::GenJet>& genJets, 
     for(size_t hadronId = 0; hadronId < genCHadJetIndex.size(); ++hadronId) {
         // Skipping c hadrons that are coming from b hadrons
         if(genCHadBHadronId.at(hadronId) >= 0) continue;
+        // Skipping c hadrons coming for W-dcays
+        if(abs(genCHadFlavour.at(hadronId))==24) continue;
+
         // Index of a jet associated to the hadron
         const int jetIndex = genCHadJetIndex.at(hadronId);
         // Whether hadron radiated before top quark decay

--- a/MiniAODHelper/src/MiniAODHelper.cc
+++ b/MiniAODHelper/src/MiniAODHelper.cc
@@ -118,7 +118,7 @@ void MiniAODHelper::SetFactorizedJetCorrector(){
 
 
 std::vector<pat::Muon> 
-MiniAODHelper::GetSelectedMuons(const std::vector<pat::Muon>& inputMuons, const float iMinPt, const muonID::muonID iMuonID, const coneSize::coneSize iconeSize, const corrType::corrType icorrType, const float iMaxEta){
+MiniAODHelper::GetSelectedMuons(const std::vector<pat::Muon>& inputMuons, const float iMinPt, const muonID::muonID iMuonID, const float iMaxEta, const coneSize::coneSize iconeSize, const corrType::corrType icorrType){
 
   CheckSetUp();
 


### PR DESCRIPTION
I implemented the neccesary changes for the new leptonID which we use in the new snychronization exercise. The functions "GetSelectedMuons" and "GetSelectedElectrons" now have a optional etacut argument with standard value 2.4. Further, I adjusted the "MuonLoose" category to be identical to the "MuonTight" category, execpt for the isolation.