### PR TITLE
New MiniAODHelper function GetJetCSV in order to take care of unohysical CSV outputs

### DIFF
--- a/MiniAODHelper/interface/MiniAODHelper.h
+++ b/MiniAODHelper/interface/MiniAODHelper.h
@@ -128,6 +128,7 @@ class MiniAODHelper{
   float GetMuonRelIso(const pat::Muon&, const coneSize::coneSize, const corrType::corrType) const;
   float GetElectronRelIso(const pat::Electron&) const;
   float GetElectronRelIso(const pat::Electron&, const coneSize::coneSize, const corrType::corrType) const;
+  static float GetJetCSV(const pat::Jet&, const std::string = "pfCombinedInclusiveSecondaryVertexV2BJetTags"); 
   bool PassesCSV(const pat::Jet&, const char);
   bool PassElectronPhys14Id(const pat::Electron&, const electronID::electronID) const;
   void addVetos(const reco::Candidate &cand);
@@ -190,7 +191,7 @@ template <typename T> T MiniAODHelper::GetSortedByPt(const T& collection){
 // === Returned sorted input collection, by descending CSV === //
 template <typename T> T MiniAODHelper::GetSortedByCSV(const T& collection){
   T result = collection;
-  std::sort(result.begin(), result.end(), [] (typename T::value_type a, typename T::value_type b) { return a.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > b.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");});
+  std::sort(result.begin(), result.end(), [] (typename T::value_type a, typename T::value_type b) { return GetJetCSV(a,"pfCombinedInclusiveSecondaryVertexV2BJetTags") > GetJetCSV(b,"pfCombinedInclusiveSecondaryVertexV2BJetTags");});
   return result;
 }
 

--- a/MiniAODHelper/src/MiniAODHelper.cc
+++ b/MiniAODHelper/src/MiniAODHelper.cc
@@ -821,10 +821,26 @@ float MiniAODHelper::GetElectronRelIso(const pat::Electron& iElectron,const cone
 }
 
 
+float MiniAODHelper::GetJetCSV(const pat::Jet& jet, const std::string taggername){
+  
+  float defaultFailure = -.1;
+  
+  float bTagVal = jet.bDiscriminator(taggername);
+
+  if(isnan(bTagVal)) return defaultFailure;
+  
+  if(bTagVal > 1.) return 1.;
+  if(bTagVal < 0.) return defaultFailure;
+  
+  return bTagVal;
+}
+
+
+
 bool MiniAODHelper::PassesCSV(const pat::Jet& iJet, const char iCSVworkingPoint){
   CheckSetUp();
 
-  float csvValue = iJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+  float csvValue = GetJetCSV(iJet,"pfCombinedInclusiveSecondaryVertexV2BJetTags");
 
   // CSV b-tagging requirement
   switch(iCSVworkingPoint){


### PR DESCRIPTION
For a consistent treatment of unphysical CSV output values the function GetJetCSV has been included.

It will treat CSV outputs in the following way:
- for nan values it will return a default failure value (set to -.1)
- for values larger than 1. it will return 1.
- for values lower than 0. it will return a default failure value (set to -.1)
- all other values will be returned unchanged

The functions GetSortedByCSV and PassesCSV have been adapted to use GetJetCSV.