### PR TITLE
Add t tbar decay categorization

### DIFF
--- a/MiniAODHelper/interface/MiniAODHelper.h
+++ b/MiniAODHelper/interface/MiniAODHelper.h
@@ -182,6 +182,16 @@ class MiniAODHelper{
   int ttHFCategorization(const std::vector<reco::GenJet>&, const std::vector<int>&, const std::vector<int>&, const std::vector<int>&, const std::vector<int>&, const std::vector<reco::GenParticle>&, const std::vector<std::vector<int> >&, const std::vector<int>&, const std::vector<int>&, const std::vector<int>&, const std::vector<int>&, const std::vector<int>&, const std::vector<int>&, const double, const double);
   int GetHiggsDecay(edm::Handle<std::vector<reco::GenParticle> >&);
   std::vector<pat::Jet> GetDeltaRCleanedJets(const std::vector<pat::Jet>&, const std::vector<pat::Muon>&, const std::vector<pat::Electron>&, const double);
+  
+  enum TTbarDecayMode{
+    ChNotDefined = 0 , 
+    SingleLepCh = 1, 
+    DiLepCh = 2 ,
+    FullHadCh = 3
+  };
+  // Top quarks "top->W->tau" are regarded as "leptonically decaying top quark" regardless of tau decay (tau->e/mu/had).
+  TTbarDecayMode GetTTbarDecay(edm::Handle<std::vector<reco::GenParticle> >& mcparticles);
+
   double getJERfactor( const int, const double, const double, const double );
   std::vector<pat::MET> CorrectMET(const std::vector<pat::Jet>& oldJetsForMET, const std::vector<pat::Jet>& newJetsForMET, const std::vector<pat::MET>& pfMETs);
   // Return weight factor dependent on number of true PU interactions
@@ -230,7 +240,40 @@ class MiniAODHelper{
 
   inline void CheckSetUp() const { if(!isSetUp){ ThrowFatalError("MiniAODHelper not yet set up."); } };
   inline void CheckVertexSetUp() const { if(!vertexIsSet){ ThrowFatalError("Vertex is not set."); } };
+
+
+ private :
+
+  struct _topquarkdecayobjects {
+    const reco::Candidate * top ; 
+    const reco::Candidate * bottom ; 
+    const reco::Candidate * W ;
+    const reco::Candidate * WChild_up;
+    const reco::Candidate * WChild_down;
+    bool isWChild_tau ; 
+    const reco::Candidate * Tau_Neu ;
+    std::vector< const reco::Candidate *> TauChildren ;
+
+    bool isLeptonicDecay(){
+      return
+	abs( WChild_down->pdgId() ) == 11
+	||
+	abs( WChild_down->pdgId() ) == 13
+	||
+	isWChild_tau ;
+    }
+
+  }; // end structure .
+
   
+  void FillTopQuarkDecayInfomration ( const reco::Candidate * c ,
+				      struct _topquarkdecayobjects * topdecayobjects) ;
+
+  bool checkIfRegisterd( const reco::Candidate * candidate , std::vector< const reco::Candidate * > list );
+
+  const reco::Candidate * GetObjectJustBeforeDecay( const reco::Candidate * particle );
+
+
 }; // End of class prototype
 
 

--- a/MiniAODHelper/src/MiniAODHelper.cc
+++ b/MiniAODHelper/src/MiniAODHelper.cc
@@ -1878,35 +1878,35 @@ void MiniAODHelper::FillTopQuarkDecayInfomration ( const reco::Candidate * c ,
 
 MiniAODHelper::TTbarDecayMode MiniAODHelper::GetTTbarDecay(edm::Handle<std::vector<reco::GenParticle> >& mcparticles){
 
-  struct _topquarkdecayobjects topPosDecay ; 
-  struct _topquarkdecayobjects topNegDecay ; 
+  struct _topquarkdecayobjects topPosDecay = { }; 
+  struct _topquarkdecayobjects topNegDecay = { }; 
 
-  std::vector<const reco::Candidate * > idx_top ; 
+  std::vector<const reco::Candidate * > idx_top_pos ; 
+  std::vector<const reco::Candidate * > idx_top_neg ; 
 
   for(size_t i=0; i<mcparticles->size();i++){
     
-    //  - - - Check Top - - - -  -
     if( abs( (*mcparticles)[i].pdgId()  ) == 6 ){
       const reco::Candidate * cand =  & (*mcparticles)[i] ; 
       cand = GetObjectJustBeforeDecay ( cand );
-      if ( ! checkIfRegisterd( cand , idx_top ) ){
-	idx_top . push_back( cand );
-	
-	if( (*mcparticles)[i].pdgId() == 6 ){
-	  // This is a top_quark
-	  FillTopQuarkDecayInfomration ( cand ,
-					 & topPosDecay ) ;
-	  
-	}else{
-	  // This is an anti-top quark
-	  FillTopQuarkDecayInfomration ( cand , 
-					 & topNegDecay ) ;
-	}
-      } // end if : this is new candidate
-    } // end if : top/anti-top quark
+      
+      if ( cand -> pdgId() == 6  && !  checkIfRegisterd( cand , idx_top_pos ) ){
+	idx_top_pos  . push_back( cand );
+	FillTopQuarkDecayInfomration ( cand ,
+				       & topPosDecay ) ;
+      }
+      
+      if ( cand -> pdgId() == - 6 && !  checkIfRegisterd( cand , idx_top_neg ) ){
+	idx_top_neg  . push_back( cand );
+	FillTopQuarkDecayInfomration ( cand , 
+				       & topNegDecay ) ;
+      }
+      
+    } // end if : |PDGID|==6
     
   }// end mcparticles-Loop.
   
+  if( idx_top_pos.size() != 1 || idx_top_neg.size() != 1 ) return ChNotDefined ;
 
   if( (   topPosDecay . isLeptonicDecay() ) && ( ! topNegDecay . isLeptonicDecay() ) ) return SingleLepCh ; 
   if( ( ! topPosDecay . isLeptonicDecay() ) && (   topNegDecay . isLeptonicDecay() ) ) return SingleLepCh ; 


### PR DESCRIPTION
New function MiniAODHelper::GetTTbarDecay() tells ttbar decay mode.
Return value is : 
    ChNotDefined = 0  // in case of error.
    SingleLepCh = 1, 
    DiLepCh = 2 ,
    FullHadCh = 3

The code is independent from other part of the tool.
I talked to Darren and Robin, and will merge them soon.

++++++++++

A validation of this code :
 with ttbar MC -- TT_TuneCUETP8M1_13TeV-powheg-pythia8, RunIIFall15MiniAODv2.

Out of 3165 events, 
SingleLepton : 1372 (Br = 43.4%)
Di-lepton : 315 (9.95%)
FullHad : 1478 (46.7%)
Exception (code failed to tell the decay mode) : 0 events.

If BR( W-> lnu ) = 32.4% is assumed (10.8% for each flavour) , the expectoration is 
 SingleLepton : Br = 43.8%
Di-lepton : 10.5%
FullHad : 45.7%

+++++++++++++