### PR TITLE
Restructure of definition in MiniAOLDHelper class :

### DIFF
--- a/MiniAODHelper/interface/MiniAODHelper.h
+++ b/MiniAODHelper/interface/MiniAODHelper.h
@@ -244,6 +244,32 @@ class MiniAODHelper{
   template <typename T, typename S> std::vector<T> GetDifference( const std::vector<S>&, const std::vector<T>& );
   template <typename T, typename S> std::vector<T> GetUnion( const std::vector<S>&, const std::vector<T>& );
 
+  struct _topquarkdecayobjects {
+    const reco::Candidate * top ;
+    const reco::Candidate * bottom ;
+    const reco::Candidate * W ;
+    const reco::Candidate * WChild_up;
+    const reco::Candidate * WChild_down;
+    bool isWChild_tau ;
+    const reco::Candidate * Tau_Neu ;
+    std::vector< const reco::Candidate *> TauChildren ;
+
+    bool isLeptonicDecay(){
+      return
+	abs( WChild_down->pdgId() ) == 11
+	||
+	abs( WChild_down->pdgId() ) == 13
+	||
+	isWChild_tau ;
+    }
+
+  }; // end structure .
+
+  static void FillTopQuarkDecayInfomration ( const reco::Candidate * c ,
+				      struct _topquarkdecayobjects * topdecayobjects) ;
+
+  static const reco::Candidate * GetObjectJustBeforeDecay( const reco::Candidate * particle );
+
  protected:
 
   bool isSetUp;
@@ -280,29 +306,7 @@ class MiniAODHelper{
   inline void CheckSetUp() const { if(!isSetUp){ ThrowFatalError("MiniAODHelper not yet set up."); } };
   inline void CheckVertexSetUp() const { if(!vertexIsSet){ ThrowFatalError("Vertex is not set."); } };
 
-
  private :
-
-  struct _topquarkdecayobjects {
-    const reco::Candidate * top ;
-    const reco::Candidate * bottom ;
-    const reco::Candidate * W ;
-    const reco::Candidate * WChild_up;
-    const reco::Candidate * WChild_down;
-    bool isWChild_tau ;
-    const reco::Candidate * Tau_Neu ;
-    std::vector< const reco::Candidate *> TauChildren ;
-
-    bool isLeptonicDecay(){
-      return
-	abs( WChild_down->pdgId() ) == 11
-	||
-	abs( WChild_down->pdgId() ) == 13
-	||
-	isWChild_tau ;
-    }
-
-  }; // end structure .
 
   void ApplyJetEnergyCorrection(pat::Jet& jet,
 				double& totalCorrFactor,
@@ -325,12 +329,8 @@ class MiniAODHelper{
   double GetJECUncertainty(const pat::Jet& jet, const edm::EventSetup& iSetup, const sysType::sysType iSysType);
 
 
-  void FillTopQuarkDecayInfomration ( const reco::Candidate * c ,
-				      struct _topquarkdecayobjects * topdecayobjects) ;
 
   bool checkIfRegisterd( const reco::Candidate * candidate , std::vector< const reco::Candidate * > list );
-
-  const reco::Candidate * GetObjectJustBeforeDecay( const reco::Candidate * particle );
 
   std::vector<double>    JER_etaMin;
   std::vector<double>    JER_etaMax;


### PR DESCRIPTION
Move functions and a structure to public. THe functions are also set to static.
structure
 _topquarkdecayobjects
function
 FillTopQuarkDecayInfomration
 GetObjectJustBeforeDecay